### PR TITLE
Fix project links & refs + bump example deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://github.com/actions/typescript-action/actions"><img alt="typescript-action status" src="https://github.com/actions/typescript-action/workflows/build-test/badge.svg"></a>
+  <a href="https://github.com/sasanquaneuf/mypy-github-action/actions"><img alt="mypy-github-action status" src="https://github.com/sasanquaneuf/mypy-github-action/workflows/build-test/badge.svg"></a>
 </p>
 
 # `mypy` GitHub Action
@@ -24,12 +24,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7.4
           architecture: x64
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Install mypy
         run: pip install mypy
       - name: Run mypy

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "typescript-action",
+  "name": "mypy-github-action",
   "version": "0.0.0",
   "private": true,
   "description": "TypeScript template action",
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/actions/typescript-action.git"
+    "url": "git+https://github.com/sasanquaneuf/mypy-github-action.git"
   },
   "keywords": [
     "actions",


### PR DESCRIPTION
- Update the CI badge to point to this project's repo instead of `actions/typescript-action`

- Update the readme example to use the latest releases of `setup-python` and `checkout`

- Update refs in package.json from `actions/typescript-action`

---

I got nodejs version warnings from GHA on my first run following the readme example, and noticed in a few places poking around that there seemed to still be some templated values :)